### PR TITLE
Feature: add client credentials flow support to KRM 

### DIFF
--- a/src/main/java/it/smartcommunitylab/dhub/rm/config/AuthenticationProperties.java
+++ b/src/main/java/it/smartcommunitylab/dhub/rm/config/AuthenticationProperties.java
@@ -79,6 +79,7 @@ public class AuthenticationProperties {
         private String audience;
         private String[] scopes;
         private String roleClaim;
+        private String clientId;
 
         public String getIssuerUri() {
             return issuerUri;
@@ -115,6 +116,14 @@ public class AuthenticationProperties {
         public void setRoleClaim(String roleClaim) {
             this.roleClaim = roleClaim;
         }
-        
+
+        public String getClientId() {      
+            return clientId;
+        }
+
+        public void setClientId(String clientId) {  
+            this.clientId = clientId;
+        }  
+
     }
 }

--- a/src/main/java/it/smartcommunitylab/dhub/rm/controller/MainController.java
+++ b/src/main/java/it/smartcommunitylab/dhub/rm/controller/MainController.java
@@ -83,7 +83,7 @@ public class MainController {
         if (authenticationProperties.isOAuth2Enabled()) {
             config.put("REACT_APP_AUTH", "oauth2");
             config.put("REACT_APP_AUTHORITY", authenticationProperties.getOauth2().getIssuerUri());
-            config.put("REACT_APP_CLIENT_ID", authenticationProperties.getOauth2().getAudience());
+            config.put("REACT_APP_CLIENT_ID", authenticationProperties.getOauth2().getClientId());
             if (authenticationProperties.getOauth2().getScopes() != null) {
                 config.put("REACT_APP_SCOPE", String.join(" ", authenticationProperties.getOauth2().getScopes()));
             }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,7 +55,7 @@ auth:
   oauth2:
     issuer-uri: ${KRM_AUTH_OAUTH2_ISSUER:}
     audience: ${KRM_AUTH_OAUTH2_AUDIENCE:}
-    client-id: ${KRM_AUTH_OAUTH2_CLIENT_ID:}
+    client-id: ${KRM_AUTH_OAUTH2_CLIENT_ID:${KRM_AUTH_OAUTH2_AUDIENCE:}}
     role-claim: ${KRM_AUTH_OAUTH2_ROLE_CLAIM:} 
     scopes: ${KRM_AUTH_OAUTH2_SCOPES:}
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -55,6 +55,7 @@ auth:
   oauth2:
     issuer-uri: ${KRM_AUTH_OAUTH2_ISSUER:}
     audience: ${KRM_AUTH_OAUTH2_AUDIENCE:}
+    client-id: ${KRM_AUTH_OAUTH2_CLIENT_ID:}
     role-claim: ${KRM_AUTH_OAUTH2_ROLE_CLAIM:} 
     scopes: ${KRM_AUTH_OAUTH2_SCOPES:}
 


### PR DESCRIPTION
This PR enables the OAuth2 client credentials flow by separating audience and clientId in the configuration.

audience continues to represent the resource server(s)

clientId identifies the OAuth2 client application

This allows KRM to support machine-to-machine authentication while maintaining backward compatibility with existing configurations.

Note: A corresponding PR to the digitalhub repository is required to update the KRM Helm chart accordingly.